### PR TITLE
Add environment variable to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,13 @@
+[build]
+  command = "bun run build"
+  publish = "build/client"
+
 [build.environment]
   SECRETS_SCAN_OMIT_KEYS = "VITE_CLERK_PUBLISHABLE_KEY"
+
+# Optional: if you have redirects
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+


### PR DESCRIPTION
Netlify creating issue : Netlify’s secret scanner doesn’t know the difference between private and publishable keys — it saw a long random string and thought it’s a secret, so it stopped the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added hosting/deployment configuration: sets build command and publish directory, omits specific keys from secrets scanning, and includes an optional redirect to serve the app entry for all routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->